### PR TITLE
Package front-end and back-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ this should result in a Jar being present in ~/.m2 and Gakusei-Admin being able 
 
 ### Package it up for deployment
 
-Will create a single .jar-file with all resources embedded. As such, front-end resources must be compiled to the back-end. Make sure you have a front-end (for example this [one](https://github.com/kits-ab/gakusei-admin-fe)). There is a pre-made maven profile for this purpose.
+Will create a single .jar-file with all resources embedded. As such, front-end resources must be compiled to the back-end. Make sure you have a front-end (designed to work with this [one](https://github.com/kits-ab/gakusei-admin-fe)). There is a pre-made maven profile for this purpose.
 
  
 - Do `mvn clean package "-Dfrontend=/where/your/frontend/is" -Pproduction` to install npm packages, compile front-end and back-end and then package the .jar-file to `target/`.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,18 @@
 
 In order to build this project one must first build Gakusei: https://github.com/kits-ab/gakusei using mvn `clean install`
 this should result in a Jar being present in ~/.m2 and Gakusei-Admin being able to find its dependencies.
+
+### Package it up for deployment
+
+Will create a single .jar-file with all resources embedded. As such, front-end resources must be compiled to the back-end. Make sure you have a front-end (for example this [one](https://github.com/kits-ab/gakusei-admin-fe)). There is a pre-made maven profile for this purpose.
+
+ 
+- Do `mvn clean package "-Dfrontend=/where/your/frontend/is" -Pproduction` to install npm packages, compile front-end and back-end and then package the .jar-file to `target/`.
+ 
+- Server can then be started using the packaged .jar-file, sample commands can be seen below:
+
+    - `nohup java -jar gakusei-admin.jar &> server.log &` for in-memory db, that clears on restart.
+
+    - `nohup java -jar gakusei-admin.jar --spring.profiles.active="postgres, enable-resource-caching" &> server.log &` for postgres
+
+

--- a/gakusei-admin/pom.xml
+++ b/gakusei-admin/pom.xml
@@ -37,10 +37,21 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-thymeleaf</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.thymeleaf</groupId>
+            <artifactId>thymeleaf</artifactId>
+            <version>3.0.3.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.thymeleaf</groupId>
+            <artifactId>thymeleaf-spring4</artifactId>
+            <version>3.0.3.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.thymeleaf.extras</groupId>
+            <artifactId>thymeleaf-extras-springsecurity4</artifactId>
+            <version>3.0.2.RELEASE</version>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
@@ -77,11 +88,6 @@
 			<version>4.12</version>
 		</dependency>
 		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<version>2.8.47</version>
-		</dependency>
-		<dependency>
 			<groupId>se.kits.gakusei</groupId>
 			<artifactId>gakusei</artifactId>
 			<version>1.0.12</version>
@@ -107,6 +113,57 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>production</id>
+			<build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <version>1.5</version>
+                        <configuration>
+                            <nodeVersion>v8.4.0</nodeVersion>
+                            <workingDirectory>${pathToFE}</workingDirectory>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>install node and npm</id>
+                                <goals>
+                                    <goal>install-node-and-npm</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>npm install</id>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                                <phase>generate-resources</phase>
+                                <configuration>
+                                    <arguments>install</arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>npm compile:production</id>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                                <phase>generate-resources</phase>
+                                <configuration>
+                                    <arguments>run compile:production</arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+                <resources>
+                    <resource>
+                        <directory>${pathToFE}/src/main/resources</directory>
+                    </resource>
+                </resources>
+			</build>
+		</profile>
+	</profiles>
 
 
 </project>

--- a/gakusei-admin/pom.xml
+++ b/gakusei-admin/pom.xml
@@ -124,7 +124,7 @@
                         <version>1.5</version>
                         <configuration>
                             <nodeVersion>v8.4.0</nodeVersion>
-                            <workingDirectory>${pathToFE}</workingDirectory>
+                            <workingDirectory>${frontend}</workingDirectory>
                         </configuration>
                         <executions>
                             <execution>
@@ -158,7 +158,7 @@
                 </plugins>
                 <resources>
                     <resource>
-                        <directory>${pathToFE}/src/main/resources</directory>
+                        <directory>${frontend}/src/main/resources</directory>
                     </resource>
                 </resources>
 			</build>

--- a/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Controllers/AdminBookController.java
+++ b/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Controllers/AdminBookController.java
@@ -1,4 +1,4 @@
-package se.kits.gakusei.gakuseiadmin.Controllers;
+package se.kits.gakusei.gakuseiadmin.controllers;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import se.kits.gakusei.content.model.Book;
 import se.kits.gakusei.content.repository.BookRepository;
-import se.kits.gakusei.controller.BookController;
 
 @RestController
 public class AdminBookController {

--- a/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Controllers/BasicController.java
+++ b/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Controllers/BasicController.java
@@ -1,4 +1,4 @@
-package se.kits.gakusei.gakuseiadmin.Controllers;
+package se.kits.gakusei.gakuseiadmin.controllers;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Controllers/FileUploadController.java
+++ b/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Controllers/FileUploadController.java
@@ -1,4 +1,4 @@
-package se.kits.gakusei.gakuseiadmin.Controllers;
+package se.kits.gakusei.gakuseiadmin.controllers;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;

--- a/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Controllers/QuizAdminController.java
+++ b/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Controllers/QuizAdminController.java
@@ -1,8 +1,5 @@
-package se.kits.gakusei.gakuseiadmin.Controllers;
+package se.kits.gakusei.gakuseiadmin.controllers;
 
-import com.univocity.parsers.common.processor.RowListProcessor;
-import com.univocity.parsers.csv.CsvParser;
-import com.univocity.parsers.csv.CsvParserSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -11,18 +8,13 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import se.kits.gakusei.content.model.Quiz;
 import se.kits.gakusei.content.repository.QuizNuggetRepository;
-import se.kits.gakusei.gakuseiadmin.Util.Csv;
-import se.kits.gakusei.gakuseiadmin.Util.FormValidator;
-import se.kits.gakusei.gakuseiadmin.Util.QuizAdminHandler;
-import se.kits.gakusei.gakuseiadmin.Util.QuizCsv;
+import se.kits.gakusei.gakuseiadmin.util.FormValidator;
+import se.kits.gakusei.gakuseiadmin.util.QuizAdminHandler;
+import se.kits.gakusei.gakuseiadmin.util.QuizCsv;
 import se.kits.gakusei.gakuseiadmin.content.AdminQuizRepository;
-import se.kits.gakusei.util.QuestionHandler;
 
 import javax.servlet.http.HttpServletRequest;
-import java.io.IOException;
-import java.io.StringReader;
 
-import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Controllers/WordTypeController.java
+++ b/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Controllers/WordTypeController.java
@@ -1,4 +1,4 @@
-package se.kits.gakusei.gakuseiadmin.Controllers;
+package se.kits.gakusei.gakuseiadmin.controllers;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;

--- a/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Util/Csv.java
+++ b/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Util/Csv.java
@@ -1,26 +1,16 @@
-package se.kits.gakusei.gakuseiadmin.Util;
+package se.kits.gakusei.gakuseiadmin.util;
 
 import com.univocity.parsers.common.processor.RowListProcessor;
 import com.univocity.parsers.csv.CsvParser;
 import com.univocity.parsers.csv.CsvParserSettings;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import se.kits.gakusei.content.model.Quiz;
-import se.kits.gakusei.gakuseiadmin.content.AdminQuizRepository;
 
 import java.io.IOException;
-import java.io.StringReader;
 
-import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import java.io.IOException;
 import java.util.Map;
 
 public class Csv {

--- a/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Util/FormValidator.java
+++ b/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Util/FormValidator.java
@@ -1,7 +1,6 @@
-package se.kits.gakusei.gakuseiadmin.Util;
+package se.kits.gakusei.gakuseiadmin.util;
 
 import org.springframework.data.repository.CrudRepository;
-import se.kits.gakusei.content.repository.QuizRepository;
 
 import java.util.HashMap;
 import java.util.List;

--- a/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Util/QuizAdminHandler.java
+++ b/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Util/QuizAdminHandler.java
@@ -1,11 +1,9 @@
-package se.kits.gakusei.gakuseiadmin.Util;
+package se.kits.gakusei.gakuseiadmin.util;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import se.kits.gakusei.content.model.IncorrectAnswers;
 import se.kits.gakusei.content.model.Quiz;
 import se.kits.gakusei.content.model.QuizNugget;
-import se.kits.gakusei.content.repository.QuizRepository;
 import se.kits.gakusei.util.QuizHandler;
 
 import java.util.ArrayList;

--- a/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Util/QuizCsv.java
+++ b/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/Util/QuizCsv.java
@@ -1,9 +1,7 @@
-package se.kits.gakusei.gakuseiadmin.Util;
+package se.kits.gakusei.gakuseiadmin.util;
 
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/Controllers/FileUploadControllerTest.java
+++ b/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/Controllers/FileUploadControllerTest.java
@@ -1,4 +1,4 @@
-package se.kits.gakusei.gakuseiadmin.Controllers;
+package se.kits.gakusei.gakuseiadmin.controllers;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -11,7 +11,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
 import se.kits.gakusei.content.model.Book;
 import se.kits.gakusei.content.model.Lesson;
 import se.kits.gakusei.content.model.WordType;
@@ -22,7 +21,6 @@ import se.kits.gakusei.gakuseiadmin.content.WordTypeRepository;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import static org.junit.Assert.*;

--- a/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/FormValidatorTest.java
+++ b/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/FormValidatorTest.java
@@ -7,7 +7,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 import se.kits.gakusei.content.model.Quiz;
 import se.kits.gakusei.content.repository.QuizRepository;
-import se.kits.gakusei.gakuseiadmin.Util.FormValidator;
+import se.kits.gakusei.gakuseiadmin.util.FormValidator;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/QuizAdminControllerTest.java
+++ b/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/QuizAdminControllerTest.java
@@ -10,15 +10,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import se.kits.gakusei.content.model.Quiz;
-import se.kits.gakusei.gakuseiadmin.Controllers.QuizAdminController;
+import se.kits.gakusei.gakuseiadmin.controllers.QuizAdminController;
 import se.kits.gakusei.gakuseiadmin.content.AdminQuizRepository;
 
 import java.io.File;

--- a/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/QuizAdminHandlerTest.java
+++ b/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/QuizAdminHandlerTest.java
@@ -1,4 +1,4 @@
-package se.kits.gakusei.util;
+package se.kits.gakusei.gakuseiadmin;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,7 +12,7 @@ import se.kits.gakusei.content.model.QuizNugget;
 import se.kits.gakusei.content.repository.IncorrectAnswerRepository;
 import se.kits.gakusei.content.repository.QuizNuggetRepository;
 import se.kits.gakusei.content.repository.QuizRepository;
-import se.kits.gakusei.gakuseiadmin.Util.QuizAdminHandler;
+import se.kits.gakusei.gakuseiadmin.util.QuizAdminHandler;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/QuizCsvUtilFailTest.java
+++ b/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/QuizCsvUtilFailTest.java
@@ -7,8 +7,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.multipart.MultipartFile;
-import se.kits.gakusei.gakuseiadmin.Util.Csv;
-import se.kits.gakusei.gakuseiadmin.Util.QuizCsv;
+import se.kits.gakusei.gakuseiadmin.util.QuizCsv;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/controllers/AdminBookControllerTest.java
+++ b/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/controllers/AdminBookControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import se.kits.gakusei.content.model.Book;
 import se.kits.gakusei.content.repository.BookRepository;
-import se.kits.gakusei.gakuseiadmin.Controllers.AdminBookController;
 
 import static org.junit.Assert.*;
 

--- a/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/controllers/WordTypeControllerTest.java
+++ b/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/controllers/WordTypeControllerTest.java
@@ -11,7 +11,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
 import se.kits.gakusei.content.model.WordType;
 import se.kits.gakusei.gakuseiadmin.content.WordTypeRepository;
-import se.kits.gakusei.gakuseiadmin.Controllers.WordTypeController;
 import se.kits.gakusei.gakuseiadmin.tools.AdminTestTools;
 
 import static org.junit.Assert.assertEquals;

--- a/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/csvUtilTest.java
+++ b/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/csvUtilTest.java
@@ -8,8 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.multipart.MultipartFile;
-import se.kits.gakusei.gakuseiadmin.Util.Csv;
-import se.kits.gakusei.gakuseiadmin.Util.QuizCsv;
+import se.kits.gakusei.gakuseiadmin.util.Csv;
 
 import java.io.File;
 import java.io.FileInputStream;


### PR DESCRIPTION
Adds a build profile "production" which will package front-end and back-end into a single .jar. This requires the front-end to be available on disk as well, and the path must be specified to maven. README was updated to explain how the build process works.

Package names were updated to be all lowercase as well, as maven failed to build unless this was done.