### PR TITLE
update controller and tests to match new quiz name uniqueness constraint

### DIFF
--- a/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/controllers/AdminQuizController.java
+++ b/gakusei-admin/src/main/java/se/kits/gakusei/gakuseiadmin/controllers/AdminQuizController.java
@@ -69,7 +69,7 @@ public class AdminQuizController {
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE
     )
     public ResponseEntity<Quiz> createQuiz(@RequestBody Quiz quiz) {
-        if (!quizRepository.findByName(quiz.getName()).isEmpty()) {
+        if (quizRepository.findByName(quiz.getName()) != null) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
 

--- a/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/tools/AdminTestTools.java
+++ b/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/tools/AdminTestTools.java
@@ -1,5 +1,8 @@
 package se.kits.gakusei.gakuseiadmin.tools;
 
+import se.kits.gakusei.content.repository.IncorrectAnswerRepository;
+import se.kits.gakusei.content.repository.QuizNuggetRepository;
+import se.kits.gakusei.content.repository.QuizRepository;
 import se.kits.gakusei.user.model.User;
 import se.kits.gakusei.content.model.*;
 import se.kits.gakusei.util.QuizHandler;
@@ -110,5 +113,11 @@ public class AdminTestTools {
             incorrectAnswers.add(incorrectAnswer);
         }
         return incorrectAnswers;
+    }
+
+    public static void tearDownQuiz(QuizRepository qr, QuizNuggetRepository qnr, IncorrectAnswerRepository iar) {
+        iar.deleteAll();
+        qnr.deleteAll();
+        qr.deleteAll();
     }
 }

--- a/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/unit/controllers/AdminQuizControllerTest.java
+++ b/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/unit/controllers/AdminQuizControllerTest.java
@@ -15,6 +15,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import se.kits.gakusei.content.model.Quiz;
+import se.kits.gakusei.content.repository.IncorrectAnswerRepository;
+import se.kits.gakusei.content.repository.QuizNuggetRepository;
 import se.kits.gakusei.content.repository.QuizRepository;
 import se.kits.gakusei.gakuseiadmin.tools.AdminTestTools;
 
@@ -40,6 +42,12 @@ public class AdminQuizControllerTest {
 
     @Autowired
     private QuizRepository quizRepository;
+
+    @Autowired
+    private QuizNuggetRepository quizNuggetRepository;
+
+    @Autowired
+    private IncorrectAnswerRepository incorrectAnswerRepository;
 
     private MockMvc mockMvc;
 
@@ -93,7 +101,7 @@ public class AdminQuizControllerTest {
             e.printStackTrace();
         }
 
-
+        AdminTestTools.tearDownQuiz(quizRepository, quizNuggetRepository, incorrectAnswerRepository);
     }
 
     @Test
@@ -107,8 +115,10 @@ public class AdminQuizControllerTest {
                     .andExpect(status().isCreated());
         } catch (Exception exc) { }
 
-        List<Quiz> quizLs = quizRepository.findByName(testQuiz.getName());
-        Assert.assertTrue(quizLs.size()>0);
+        Quiz quiz = quizRepository.findByName(testQuiz.getName());
+        Assert.assertTrue(quiz != null);
+
+        AdminTestTools.tearDownQuiz(quizRepository, quizNuggetRepository, incorrectAnswerRepository);
     }
 
     @Test
@@ -127,6 +137,8 @@ public class AdminQuizControllerTest {
         Quiz quiz1 = quizRepository.findOne(quiz.getId());
         Assert.assertEquals(quiz.getId(), quiz1.getId());
         Assert.assertEquals(quiz.getDescription()+" NEW", quiz1.getDescription());
+
+        AdminTestTools.tearDownQuiz(quizRepository, quizNuggetRepository, incorrectAnswerRepository);
     }
 
     @Test
@@ -139,6 +151,8 @@ public class AdminQuizControllerTest {
         } catch (Exception exc) { }
 
         Assert.assertEquals(false, quizRepository.exists(testQuiz.getId()));
+
+        AdminTestTools.tearDownQuiz(quizRepository, quizNuggetRepository, incorrectAnswerRepository);
     }
 
     @Test
@@ -156,6 +170,8 @@ public class AdminQuizControllerTest {
                     .content(questionsString))
                     .andExpect(status().isCreated());
         } catch (Exception exc) { }
+
+        AdminTestTools.tearDownQuiz(quizRepository, quizNuggetRepository, incorrectAnswerRepository);
     }
 
     @Test
@@ -175,5 +191,6 @@ public class AdminQuizControllerTest {
                     .andExpect(status().isBadRequest());
         } catch (Exception exc) { }
 
+        AdminTestTools.tearDownQuiz(quizRepository, quizNuggetRepository, incorrectAnswerRepository);
     }
 }

--- a/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/unit/util/AdminQuizHandlerTest.java
+++ b/gakusei-admin/src/test/java/se/kits/gakusei/gakuseiadmin/unit/util/AdminQuizHandlerTest.java
@@ -12,6 +12,7 @@ import se.kits.gakusei.content.model.QuizNugget;
 import se.kits.gakusei.content.repository.IncorrectAnswerRepository;
 import se.kits.gakusei.content.repository.QuizNuggetRepository;
 import se.kits.gakusei.content.repository.QuizRepository;
+import se.kits.gakusei.gakuseiadmin.tools.AdminTestTools;
 import se.kits.gakusei.gakuseiadmin.util.AdminQuizHandler;
 
 import java.util.ArrayList;
@@ -91,6 +92,8 @@ public class AdminQuizHandlerTest {
 
         assertTrue(quizNugget.containsKey("id"));
         assertTrue(this.quizNuggetRepository.exists((Long) quizNugget.get("id")));
+
+        AdminTestTools.tearDownQuiz(quizRepository, quizNuggetRepository, incorrectAnswerRepository);
     }
 
     @Test
@@ -113,5 +116,7 @@ public class AdminQuizHandlerTest {
         } catch (Exception exc) {
             assert false;
         }
+
+        AdminTestTools.tearDownQuiz(quizRepository, quizNuggetRepository, incorrectAnswerRepository);
     }
 }


### PR DESCRIPTION
These changes are needed due to the new uniqueness constraint in https://github.com/kits-ab/gakusei/pull/457
* update create quiz in controller
* delete quizzes, quiz nuggets and incorrect answers after each test
(to not violate the uniqueness constraint in the tests when creating and saving test data to quiz repository)